### PR TITLE
AEM admin password change

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,10 +13,17 @@ dependencies:
         aem_service_port: "{{ conga_config.quickstart.port }}",
         aem_service_name: "{{ aem_cms_service_name }}"
     }
-    # manage users (e.g. change password of admin user)
+    # apply security changes
   - {
-      role: aem-user,
-      aem_user_aem_port: "{{ conga_config.quickstart.port }}",
+      role: aem-security,
+      aem_security_aem_port: "{{ conga_config.quickstart.port }}",
+      aem_security_admin_username: "{{ conga_config.aem.admin.username }}",
+      aem_security_admin_password_new: "{{ conga_config.aem.admin.password }}",
+      aem_security_admin_password_old: "{{ conga_config.aem.admin.passwordOld }}",
+      when: conga_config.aem.admin.username is defined and conga_config.aem.admin.username != ""
+            and conga_config.aem.admin.password is defined and conga_config.aem.admin.password != ""
+            and conga_config.aem.admin.passwordOld is defined and conga_config.aem.admin.passwordOld != ""
+            and conga_config.aem.admin.password != conga_config.aem.admin.passwordOld
     }
   - {
       role: conga-bundle-files,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,17 +13,17 @@ dependencies:
         aem_service_port: "{{ conga_config.quickstart.port }}",
         aem_service_name: "{{ aem_cms_service_name }}"
     }
-    # apply security changes
+    # apply security role (change admin password if configured and necessary)
   - {
       role: aem-security,
       aem_security_aem_port: "{{ conga_config.quickstart.port }}",
-      aem_security_admin_username: "{{ conga_config.aem.admin.username }}",
-      aem_security_admin_password_new: "{{ conga_config.aem.admin.password }}",
-      aem_security_admin_password_old: "{{ conga_config.aem.admin.passwordOld }}",
-      when: conga_config.aem.admin.username is defined and conga_config.aem.admin.username != ""
-            and conga_config.aem.admin.password is defined and conga_config.aem.admin.password != ""
-            and conga_config.aem.admin.passwordOld is defined and conga_config.aem.admin.passwordOld != ""
-            and conga_config.aem.admin.password != conga_config.aem.admin.passwordOld
+      aem_security_admin_username: "{{ conga_config.quickstart.adminUser.username }}",
+      aem_security_admin_password_new: "{{ conga_config.quickstart.adminUser.password }}",
+      aem_security_admin_password_old: "{{ conga_config.quickstart.adminUser.passwordOld }}",
+      when: conga_config.quickstart.adminUser.username is defined and conga_config.quickstart.adminUser.username != ""
+            and conga_config.quickstart.adminUser.password is defined and conga_config.quickstart.adminUser.password != ""
+            and conga_config.quickstart.adminUser.passwordOld is defined and conga_config.quickstart.adminUser.passwordOld != ""
+            and conga_config.quickstart.adminUser.password != conga_config.quickstart.adminUser.passwordOld
     }
   - {
       role: conga-bundle-files,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,17 @@ dependencies:
       conga_files_owner: "{{ aem_cms_user }}",
       conga_files_group: "{{ aem_cms_group }}",
       conga_files_mode: "0755",
-      conga_files_handlers: [ restart aem ]
+      conga_files_handlers: [ restart aem ],
+    }
+    # ensure service is started
+  - { name: aem-service,
+        aem_service_port: "{{ conga_config.quickstart.port }}",
+        aem_service_name: "{{ aem_cms_service_name }}"
+    }
+    # change manage users (e.g. changed password of admin user)
+  - {
+      role: aem-user,
+      aem_user_aem_port: "{{ conga_config.quickstart.port }}",
     }
   - {
       role: conga-bundle-files,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,7 @@ dependencies:
         aem_service_port: "{{ conga_config.quickstart.port }}",
         aem_service_name: "{{ aem_cms_service_name }}"
     }
-    # change manage users (e.g. changed password of admin user)
+    # manage users (e.g. change password of admin user)
   - {
       role: aem-user,
       aem_user_aem_port: "{{ conga_config.quickstart.port }}",


### PR DESCRIPTION
This PR is related to:
* https://github.com/wcm-io-devops/conga-aem-definitions/pull/23

When 
* quickstart.adminUser.username and
* quickstart.adminUser.password and
* quickstart.adminUser.passwordOld 

are set, different and valid, the admin password (OAK) is changed during provisioning.
The passsword change for the Apache Felix OSGi Webconsole is done by OSGi configuration (https://github.com/wcm-io-devops/conga-aem-definitions/pull/23/files#diff-7f092d4bbdc788361dfd0025f105077f)