### PR TITLE
Ansible 2.8 compatibility

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -42,7 +42,7 @@ dependencies:
     }
     # ensure service is started
   - { name: wcm_io_devops.aem_service,
-      version: 1.2.0,
+      version: 1.3.0,
       aem_service_port: "{{ conga_config.quickstart.port }}",
       aem_service_name: "{{ aem_cms_service_name }}",
       aem_service_state: started

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -73,7 +73,7 @@ dependencies:
       conga_bundle_files_standalone: false,
     }
   - { role: wcm_io_devops.conga_aem_packages,
-      version: 1.3.0,
+      version: 2.0.0,
       conga_aem_packages_port: "{{ conga_config.quickstart.port }}",
       aem_service_name: "{{ aem_cms_service_name }}",
       conga_aem_packages_standalone: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,7 +30,7 @@ galaxy_info:
 dependencies:
   - {
       role: wcm_io_devops.conga_facts,
-      version: 1.0.1
+      version: 1.1.0
     }
   - {
       role: wcm_io_devops.conga_files,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -63,7 +63,7 @@ dependencies:
     }
   - {
       role: wcm_io_devops.conga_bundle_files,
-      version: 1.2.0,
+      version: 2.0.0,
       conga_bundle_files_base_path: "{{ conga_config.quickstart.rootPath }}",
       conga_bundle_files_owner: "{{ aem_cms_user }}",
       conga_bundle_files_group: "{{ aem_cms_group }}",

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -38,8 +38,7 @@ dependencies:
       conga_files_base_path: "{{ conga_config.quickstart.rootPath }}/crx-quickstart",
       conga_files_owner: "{{ aem_cms_user }}",
       conga_files_group: "{{ aem_cms_group }}",
-      conga_files_mode: "0755",
-      conga_files_handlers: [ restart aem ],
+      conga_files_mode: "0755"
     }
     # ensure service is started
   - { name: wcm_io_devops.aem_service,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -34,7 +34,7 @@ dependencies:
     }
   - {
       role: wcm_io_devops.conga_files,
-      version: 1.0.1,
+      version: 1.1.0,
       conga_files_base_path: "{{ conga_config.quickstart.rootPath }}/crx-quickstart",
       conga_files_owner: "{{ aem_cms_user }}",
       conga_files_group: "{{ aem_cms_group }}",

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -69,10 +69,9 @@ dependencies:
       conga_bundle_files_owner: "{{ aem_cms_user }}",
       conga_bundle_files_group: "{{ aem_cms_group }}",
       conga_bundle_files_mode: "0600",
-      conga_bundle_files_aem_port: "{{ conga_config.quickstart.port }}",
-      conga_bundle_files_handlers: [ restart aem ],
+      conga_bundle_files_aem_service_port: "{{ conga_config.quickstart.port }}",
+      conga_bundle_files_aem_service_name: "{{ aem_cms_service_name }}",
       conga_bundle_files_standalone: false,
-      aem_service_name: "{{ aem_cms_service_name }}",
     }
   - { role: wcm_io_devops.conga_aem_packages,
       version: 1.3.0,

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,9 @@
+- name: Restart AEM when required.
+  import_role:
+    name: wcm_io_devops.aem_service
+  vars:
+    aem_service_name: "{{ aem_cms_service_name }}"
+    aem_service_port: "{{ conga_config.quickstart.port }}"
+    aem_service_state: restarted
+  when:
+    - _conga_files_result and _conga_files_result.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,21 @@
+- name: Debug output.
+  debug:
+    msg:
+      - "conga_aem_packages_aem_restarted: {{ conga_aem_packages_aem_restarted | default(None) }}"
+      - "conga_files_changed: {{ conga_files_changed | default(None) }}"
+      - "conga_bundle_files_changed: {{ conga_bundle_files_changed | default(None) }}"
+    verbosity: 1
+
+# restart AEM when it was not restarted during package installation but
+# wcm_io_devops.conga_files and wcm_io_devops.conga_bundle_files have changed.
 - name: Restart AEM when required. # noqa 503
-  import_role:
+  include_role:
     name: wcm_io_devops.aem_service
   vars:
     aem_service_name: "{{ aem_cms_service_name }}"
     aem_service_port: "{{ conga_config.quickstart.port }}"
     aem_service_state: restarted
   when:
-    - _conga_files_result and _conga_files_result.changed
+    - not conga_aem_packages_aem_restarted | default(false)
+    - (conga_files_changed | default(false))
+      or (conga_bundle_files_changed | default(false))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Restart AEM when required.
+- name: Restart AEM when required. # noqa 503
   import_role:
     name: wcm_io_devops.aem_service
   vars:


### PR DESCRIPTION
This PR makes the role compatible with Ansible 2.8+.
The main issue with Ansible 2.8+ is that the implemented restart mechanisms in the roles
* wcm_io_devops.conga_files
* wcm_io_devops.conga_bundle_files
* wcm_io_devops.conga_aem_packages

have stopped working. 

Basically this PR changes the restart logic of the role and moves it from handlers to explicit restarts.

This PR depends on the following PRs from the dependend roles:
* https://github.com/wcm-io-devops/ansible-aem-service/pull/10
* https://github.com/wcm-io-devops/ansible-conga-files/pull/6
* https://github.com/wcm-io-devops/ansible-conga-bundle-files/pull/10
* https://github.com/wcm-io-devops/ansible-conga-aem-packages/pull/23

We are now using the result facts from [wcm_io_devops.conga_files](https://github.com/wcm-io-devops/ansible-conga-files), [wcm_io_devops.conga_bundle_files](https://github.com/wcm-io-devops/ansible-conga-bundle-files) and [wcm_io_devops.conga_aem_packages](https://github.com/wcm-io-devops/ansible-conga-aem-packages) to determine if a restart is required or not after the roles were applied.

In order to merge this PR we need to merge the dependend PRs before and release the roles to Ansible Galaxy.
